### PR TITLE
Fix compilation error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -299,7 +299,7 @@ dependencies = [
 
 [[package]]
 name = "sledtool"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "argh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sledtool"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Vitaly _Vi Shukela <vi0oss@gmail.com>"]
 edition = "2018"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Commands:
 
 ```
 $ sledtool <dbname> get --help
-Usage: sledtool get <key> [-t <tree>] [-r] [-R] [-T] [-g] [-l] [-K] [-q] [-f] [-l]
+Usage: sledtool get <key> [-t <tree>] [-r] [-R] [-T] [--gt] [--lt] [-K] [-q] [-f] [-l]
 
 Get value of specific key (or first/last) from the database
 
@@ -49,8 +49,8 @@ Options:
   -R, --raw-key     inhibit hex-decoding or hex-encoding the key
   -T, --raw-tree-name
                     inhibit hex-decoding the tree name
-  -g, --gt          use `get_gt` instead of `get`
-  -l, --lt          use `get_lt` instead of `get`
+  --gt              use `get_gt` instead of `get`
+  --lt              use `get_lt` instead of `get`
   -K, --print-key   print key in addition to the value, with `=` sign in between
   -q, --quiet       do not print `Not found` to console, just set exit code 1
   -f, --first       ignore key, get first record instead
@@ -59,7 +59,7 @@ Options:
 ```
 
 ```
-$ sledtool qqq export
+$ sledtool /path/to/db export
 {
  "5f5f736c65645f5f64656661756c74":{
   "71717132": "71776572747961736466"

--- a/src/main.rs
+++ b/src/main.rs
@@ -64,11 +64,11 @@ struct Get {
     raw_tree_name: bool,
 
     /// use `get_gt` instead of `get`
-    #[argh(switch, short = 'g')]
+    #[argh(switch)]
     gt: bool,
 
     /// use `get_lt` instead of `get`
-    #[argh(switch, short = 'l')]
+    #[argh(switch)]
     lt: bool,
 
     /// print key in addition to the value, with `=` sign in between


### PR DESCRIPTION
## Problem

`cargo build` fails:
```
error: The short name of "-l" was already used here.
  --> src/main.rs:70:5
   |
70 | /     /// use `get_lt` instead of `get`
71 | |     #[argh(switch, short = 'l')]
72 | |     lt: bool,
   | |____________^

error: Later usage here.
  --> src/main.rs:86:5
   |
86 | /     /// ignore key, get last record instead
87 | |     #[argh(switch, short = 'l')]
88 | |     last: bool,
   | |______________^

error: could not compile `sledtool` due to 2 previous errors
```

## Solution

Remove `-l` short option from `get` command. Use long options (`--gt` and `--lt`) instead.